### PR TITLE
Vban sender optimize

### DIFF
--- a/src/vbanpacketreceiver.cpp
+++ b/src/vbanpacketreceiver.cpp
@@ -110,6 +110,9 @@ namespace nap
 		if(!errorState.check((hdr->format_bit & VBAN_RESERVED_MASK) == 0, "reserved format bit invalid value"))
 			return false;
 
+        if(!errorState.check((hdr->format_nbc + 1) > 0, "channel count cannot be 0 or smaller"))
+            return false;
+
 		// check protocol and codec
 		protocol        = static_cast<VBanProtocol>(hdr->format_SR & VBAN_PROTOCOL_MASK);
 		codec           = static_cast<VBanCodec>(hdr->format_bit & VBAN_CODEC_MASK);

--- a/src/vbansendernode.cpp
+++ b/src/vbansendernode.cpp
@@ -112,7 +112,7 @@ namespace nap
 
                 // if total buffersize exceeds max data size, resize packet channel size to fit max data size
                 if (mPacketChannelSize * mChannelCount > VBAN_DATA_MAX_SIZE)
-                    mPacketChannelSize = VBAN_DATA_MAX_SIZE / mChannelCount;
+                    mPacketChannelSize = (VBAN_DATA_MAX_SIZE / (mChannelCount * 2)) * 2;
 
                 // compute the buffer size of all channels together
                 int totalBufferSize = mPacketChannelSize * mChannelCount;
@@ -136,7 +136,5 @@ namespace nap
                     mPacketChannelOffsets[channel] = &mPacketBuffer[VBAN_HEADER_SIZE + channel * mPacketChannelSize];
             }
         }
-
-
 	}
 }

--- a/src/vbansendernode.cpp
+++ b/src/vbansendernode.cpp
@@ -62,6 +62,7 @@ namespace nap
                     char byte_1 = value;
                     char byte_2 = value >> 8;
 
+                    // copy sample bytes to packet
                     mPacketChannelOffsets[channel][mPacketWritePosition] = byte_1;
                     mPacketChannelOffsets[channel][mPacketWritePosition + 1] = byte_2;
                 }
@@ -69,6 +70,7 @@ namespace nap
 
                 if (mPacketWritePosition == mPacketChannelSize)
                 {
+                    // set the frame counter in the VBAN header
                     mPacketHeader->nuFrame = mFrameCounter;
 
                     // create udp packet & send
@@ -128,6 +130,7 @@ namespace nap
                 mPacketHeader->nuFrame    = mFrameCounter;
                 mPacketHeader->format_nbs = (totalBufferSize / ((mPacketHeader->format_nbc + 1) * VBanBitResolutionSize[(mPacketHeader->format_bit & VBAN_BIT_RESOLUTION_MASK)])) - 1;
 
+                // administer offsets of each channel in the VBAN packet
                 mPacketChannelOffsets.resize(mChannelCount);
                 for (auto channel = 0; channel < mChannelCount; ++channel)
                     mPacketChannelOffsets[channel] = &mPacketBuffer[VBAN_HEADER_SIZE + channel * mPacketChannelSize];

--- a/src/vbansendernode.h
+++ b/src/vbansendernode.h
@@ -7,6 +7,8 @@
 // Std includes
 #include <atomic>
 
+#include <vban/vban.h>
+
 #include <udpclient.h>
 
 // Audio includes
@@ -44,7 +46,7 @@ namespace nap
 
 		private:
             void setChannelCount(int channelCount);
-            int getChannelCount() const { return mBuffers.size(); }
+            int getChannelCount() const { return mChannelCount; }
             void processBuffer(const SampleBuffer& buffer, int channel);
 
             // Inherited from Node
@@ -52,7 +54,13 @@ namespace nap
             void sampleRateChanged(float) override;
 
             std::vector<std::vector<audio::SampleValue>*> mInputPullResult;
-            std::vector<std::vector<char>> mBuffers;
+            int mChannelCount = 0;
+            int mBufferSizePerChannel = 0;
+            int mBufferWritePosition = 0;
+            std::vector<nap::uint8> mBuffer;
+            std::vector<nap::uint8*> mBufferChannelOffsets;
+            VBanHeader* mVBANHeader = nullptr;
+
             uint32_t mFrameCount = 0;
             uint8_t mSampleRateFormat = 0;
             std::string mStreamName;

--- a/src/vbansendernode.h
+++ b/src/vbansendernode.h
@@ -55,13 +55,13 @@ namespace nap
 
             std::vector<std::vector<audio::SampleValue>*> mInputPullResult;
             int mChannelCount = 0;
-            int mBufferSizePerChannel = 0;
-            int mBufferWritePosition = 0;
-            std::vector<nap::uint8> mBuffer;
-            std::vector<nap::uint8*> mBufferChannelOffsets;
-            VBanHeader* mVBANHeader = nullptr;
+            int mPacketChannelSize = 0;
+            int mPacketWritePosition = 0;
+            std::vector<nap::uint8> mPacketBuffer;
+            std::vector<nap::uint8*> mPacketChannelOffsets;
+            VBanHeader* mPacketHeader = nullptr;
 
-            uint32_t mFrameCount = 0;
+            uint32_t mFrameCounter = 0;
             uint8_t mSampleRateFormat = 0;
             std::string mStreamName;
             UDPClient* mUDPClient = nullptr;

--- a/src/vbanstreamplayercomponent.cpp
+++ b/src/vbanstreamplayercomponent.cpp
@@ -67,7 +67,7 @@ namespace nap
 
 		void VBANStreamPlayerComponentInstance::pushBuffers(std::vector<std::vector<float>>& buffers)
 		{
-			if(buffers.size() == getChannelCount())
+			if(buffers.size() >= getChannelCount())
 			{
 				for(int i = 0; i < mBufferPlayers.size(); i++)
 				{


### PR DESCRIPTION
Volgens mij is het zo weer een stukje simpeler en sneller!
Die hele tussen-buffer is er nu uit, samples worden direct vanuit de input buffer geconverteerd en meteen naar het VBAN packet geschreven.